### PR TITLE
No need for plugin on client

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 paraview_add_plugin(pvNek5000Reader
   REQUIRED_ON_SERVER
-  REQUIRED_ON_CLIENT
   VERSION "1.0"
   MODULES Nek5000Reader
   MODULE_FILES      "${CMAKE_CURRENT_SOURCE_DIR}/Reader/vtk.module")


### PR DESCRIPTION
Does it make sense to just remove this tag requiring the plugin on the client?  It seems it may not be necessary.